### PR TITLE
Rename #generating_external_link method to Rename #generate_external_link

### DIFF
--- a/lib/sumsub/request.rb
+++ b/lib/sumsub/request.rb
@@ -171,7 +171,7 @@ module Sumsub
 
     # API docs: https://developers.sumsub.com/api-reference/additional-methods.html#generating-websdk-external-link-for-particular-user
     # Sumsub::Struct::Applicant can be used as body.
-    def generating_external_link(level_name, ttl_in_seconds, external_user_id, locale: nil, body: nil)
+    def generate_external_link(level_name, ttl_in_seconds, external_user_id, locale: nil, body: {})
       resource = "sdkIntegrations/levels/#{level_name}/websdkLink?ttlInSecs=#{ttl_in_seconds}&externalUserId=#{external_user_id}&lang=#{locale}"
       headers = build_header(resource, method: 'POST', body: body.to_json)
 

--- a/spec/sumsub/request_spec.rb
+++ b/spec/sumsub/request_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe Sumsub::Request do
     end
   end
 
-  describe "#generating_external_link" do
+  describe "#generate_external_link" do
     let(:level_name) { 'basic-kyc-level' }
     let(:ttl_in_seconds) { 1800 }
     let(:external_user_id) { 'appt23' }
@@ -512,7 +512,7 @@ RSpec.describe Sumsub::Request do
         args: { json: applicant }
       )
 
-      described_class.new.generating_external_link(level_name, ttl_in_seconds, external_user_id, locale: locale, body: applicant)
+      described_class.new.generate_external_link(level_name, ttl_in_seconds, external_user_id, locale: locale, body: applicant)
     end
   end
 


### PR DESCRIPTION
Sorry, I made a mistake in the naming.