### PR TITLE
Fix review_result struct

### DIFF
--- a/lib/sumsub/struct/review_result.rb
+++ b/lib/sumsub/struct/review_result.rb
@@ -5,7 +5,7 @@ module Sumsub
     # https://developers.sumsub.com/api-reference/#request-body-4
     class ReviewResult < BaseStruct
       attribute :reviewAnswer, Types::ReviewAnswers
-      attribute :rejectLabels, Types::Array.of(Types::RejectLabels)
+      attribute? :rejectLabels, Types::Array.of(Types::RejectLabels)
       attribute? :reviewRejectType, Types::ReviewRejectTypes
       attribute? :clientComment, Types::String
       attribute? :moderationComment, Types::String


### PR DESCRIPTION
A typo in the documentation. This is an optional attribute.