### PR TITLE
Replace deprecated reject label with new ones

### DIFF
--- a/lib/sumsub/types.rb
+++ b/lib/sumsub/types.rb
@@ -51,7 +51,9 @@ module Sumsub
     RejectLabels = Types::Strict::Symbol
       .constructor(&:to_sym)
       .enum(
-        :FORGERY,
+        :FORCED_VERIFICATION,
+        :LIVENESS_WITH_PHONE,
+        :DEEPFAKE,
         :DOCUMENT_TEMPLATE,
         :LOW_QUALITY,
         :SPAM,


### PR DESCRIPTION
Starting December 2nd, Sumsub will be introducing new rejection labels to replace the current **FORGERY** label on 3 specific buttons. These changes are aimed at providing clearer reasons for rejections, making it easier to identify issues with a rejected applicant. The following labels will be added:

1) Forced verification button - for applicants with suspicion of coercion from third parties: **FORGERY** label will be replaced with **FORCED_VERIFICATION** label.
2) Liveness with phone button - for applicants holding a phone during the Liveness check: **FORGERY** label will be replaced with **LIVENESS_WITH_PHONE** label.
3) Deepfake button - for applicants with suspected deepfake usage: **FORGERY** label will be replaced with **DEEPFAKE** label.