### PR TITLE
Fix WebhookSender.get_payload

### DIFF
--- a/lib/sumsub/webhook_sender.rb
+++ b/lib/sumsub/webhook_sender.rb
@@ -10,6 +10,7 @@ module Sumsub
       )
       .gsub("[\n      \"", "[ \"")
       .gsub("\n    ]", " ]")
+      .gsub("\n      ", " ")
     end
   end
 end


### PR DESCRIPTION
It fixes an error that occurs when a webhook request contains a failed KYC verification.